### PR TITLE
Use document.documentElement to retrieve HTML tag

### DIFF
--- a/gmail/script.js
+++ b/gmail/script.js
@@ -1,7 +1,7 @@
 
 // == SIMPL =====================================================
 // Add simpl style to html tag
-var htmlEl = document.getElementsByTagName('html')[0];
+var htmlEl = document.documentElement;
 htmlEl.classList.add('simpl');
 
 // Add keyboard shortcut for toggling on/off custom style


### PR DESCRIPTION
Per https://developer.mozilla.org/en-US/docs/Web/API/Document/documentElement

> Document.documentElement returns the Element that is the root element of the document (for example, the <html> element for HTML documents).