### PR TITLE
Fix for tab panels drifting 1em below the window

### DIFF
--- a/gmail/style.css
+++ b/gmail/style.css
@@ -370,6 +370,7 @@ html.simpl .AO .aeF > .nH {
 /* Add extra padding between inbox groups */
 html.simpl div[role="tabpanel"] {
 	padding-bottom: 1em;
+	box-sizing: border-box;
 }
 
 /* Hide toggle next to inbox groups */


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/41373/55744754-80d25c80-59ea-11e9-8df4-5d71550784b0.png)

After:

![image](https://user-images.githubusercontent.com/41373/55744792-99db0d80-59ea-11e9-8307-7d867ea39d27.png)
