### PR TITLE
Align action bar to Inbox at >= 1140px wide

### DIFF
--- a/gmail/style.css
+++ b/gmail/style.css
@@ -155,6 +155,28 @@ html.simpl.hideSearch .aeH {
 	width: calc(100vw - 172px);
 }
 
+/* At >= 1100px wide, align action bar to Inbox */
+@media only screen and (min-width: 1000px) {
+	html.simpl.hideSearch .aeH .G-atb {
+		margin-left: 196px !important;
+	}
+}
+@media only screen and (min-width: 1287px) {
+	html.simpl.hideSearch .aeH .G-atb {
+		margin-left: calc((100vw - 960px + 64px) / 2) !important;
+	}
+}
+@media only screen and (min-width: 1450px) {
+	html.simpl.hideSearch .aeH .G-atb {
+		margin-left: calc((100vw - 1100px + 64px) / 2) !important;
+	}
+}
+@media only screen and (min-width: 1600px) {
+	html.simpl .aeH .G-atb {
+		margin-left: calc((100vw - 1100px + 64px) / 2) !important;
+	}
+}
+
 /* Dim pagination controls unless hovered over */
 /* BUG: the pagination controls are on each section in Priority Inbox */
 html.simpl .aeH .G-atb .aqJ,

--- a/gmail/style.css
+++ b/gmail/style.css
@@ -155,8 +155,8 @@ html.simpl.hideSearch .aeH {
 	width: calc(100vw - 172px);
 }
 
-/* At >= 1100px wide, align action bar to Inbox */
-@media only screen and (min-width: 1000px) {
+/* At >= 1040px wide, align action bar to Inbox */
+@media only screen and (min-width: 1040px) {
 	html.simpl.hideSearch .aeH .G-atb {
 		margin-left: 196px !important;
 	}


### PR DESCRIPTION
I personally find it more useful when the action bar is aligned with the Inbox.

These changes align the action bar to the Inbox at different breakpoints and when the search bar is not open; except at `>= 1600px`, where it’s wide enough to have both the action bar and search bar open without overlapping.

I realize this can be messy to maintain if Gmail changes; but thought it was worth opening a PR in case it’s worth it (since I created a fork for myself).

Excellent work on this extension, btw—I love it!

---

Not aligned on smaller viewport sizes
![image](https://user-images.githubusercontent.com/359871/56820382-5cabb380-6811-11e9-94ce-1df46ec016e4.png)
Aligns at `>= 1041px`
![image](https://user-images.githubusercontent.com/359871/56820203-e313c580-6810-11e9-86a9-4182ea2eff73.png)
Action bar next to menu when search bar is open
![image](https://user-images.githubusercontent.com/359871/56820208-e4dd8900-6810-11e9-82b8-50b434e7a9c3.png)