### PR TITLE
#43 - Implement page action to toggle on and off simplify

### DIFF
--- a/gmail/manifest.json
+++ b/gmail/manifest.json
@@ -11,6 +11,21 @@
 		"128": "img/icon128.png"
 	},
 
+	"page_action": {
+		"default_icon": {
+			"16": "img/icon16.png",
+			"24": "img/icon24.png",
+			"32": "img/icon32.png",
+			"48": "img/icon48.png",
+			"128": "img/icon128.png"
+		}
+	},
+
+	"background": {
+		"scripts": [ "pageActionHandler.js" ],
+		"persistent": false
+	},
+
 	"content_scripts": [{
       	"matches": ["*://mail.google.com/mail/*"],
       	"js": ["script.js"],

--- a/gmail/pageActionHandler.js
+++ b/gmail/pageActionHandler.js
@@ -1,0 +1,26 @@
+const toggleOnTitle = 'Toggle simplify on';
+const toggleOffTitle = 'Toggle simplify off';
+
+function updateTitle(tabId, toggled){
+    chrome.pageAction.setTitle({
+        tabId: tabId,
+        title: toggled ? toggleOffTitle : toggleOnTitle
+    });
+}
+
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
+    if (message.action === 'activate_page_action') {
+        const tabId = sender.tab.id;
+
+        updateTitle(tabId, true);
+        chrome.pageAction.show(tabId);
+    }
+});
+
+chrome.pageAction.onClicked.addListener(function (tab){
+    const tabId = tab.id;
+
+	chrome.tabs.sendMessage(tabId, {action: 'toggle_simpl'}, function(response) {
+        updateTitle(tabId, response.toggled);
+    });
+});

--- a/gmail/script.js
+++ b/gmail/script.js
@@ -17,15 +17,32 @@ var simplifyDebug = true;
 var htmlEl = document.documentElement;
 htmlEl.classList.add('simpl');
 
+// Toggles custom style and returns latest state
+function toggleSimpl(){
+	return htmlEl.classList.toggle('simpl');
+}
+
 // Add keyboard shortcut for toggling on/off custom style
-function toggleSimpl(event) {
+function handleToggleShortcut(event) {
 	// If Cmd+J was pressed, toggle simpl
 	if (event.metaKey && event.which == 74) {
-		htmlEl.classList.toggle('simpl');
+		toggleSimpl();
 		event.preventDefault();
 	}
 }
-window.addEventListener('keydown', toggleSimpl, false);
+
+window.addEventListener('keydown', handleToggleShortcut, false);
+
+// Handle messages from background script
+chrome.runtime.onMessage.addListener(function (message, sender, sendResponse){
+	if (message.action === 'toggle_simpl'){
+		const isNowToggled = toggleSimpl();
+		sendResponse({toggled: isNowToggled});
+	}
+});
+
+// Activate page action button
+chrome.runtime.sendMessage({action: 'activate_page_action'});
 
 /* Add simpl Toggle button
 window.addEventListener('load', function() {


### PR DESCRIPTION
I've used the icons, that were mentioned in #43 (extension icon). If you want custom one, or change the icon based on the toggle status just tell me, and I will replace with whatever you say.

Regarding tooltip text: 
Toggle off - `Toggle simplify off`
Toggle on - `Toggle simplify on`

I've implemented toggle without persistence and its state is maintained for each tab separately, so simplify will restore to `toggled on` state each time new tab is opened or current one is refreshed (like your shortcut), tell me if I you want to change that.

Overall works as expected:

![simplify-page-action-demo](https://user-images.githubusercontent.com/34073648/56849296-64e01d80-68fb-11e9-93e5-1f5e9c02bc05.gif)
