### PR TITLE
#43 - fix icons scaling

### DIFF
--- a/gmail/manifest.json
+++ b/gmail/manifest.json
@@ -10,15 +10,7 @@
 		"48": "img/icon48.png",
 		"128": "img/icon128.png"
 	},
-	"page_action": {
-		"default_icon": {
-			"16": "img/icon16.png",
-			"24": "img/icon24.png",
-			"32": "img/icon32.png",
-			"48": "img/icon48.png",
-			"128": "img/icon128.png"
-		}
-	},
+	"page_action": {},
 	"content_scripts": [{
       	"matches": ["*://mail.google.com/mail/*"],
       	"js": ["script.js"],

--- a/gmail/pageActionHandler.js
+++ b/gmail/pageActionHandler.js
@@ -1,17 +1,31 @@
 const toggleOnTitle = 'Enable Simplify';
 const toggleOffTitle = 'Temporarily disable Simplify';
 
-function updateTitle(tabId, toggled) {
+const toggledOnIcon = {
+    16: "img/icon16.png",
+    24: "img/icon24.png",
+	32: "img/icon32.png",
+	48: "img/icon48.png",
+	128: "img/icon128.png"
+}
+
+const toggledOffIcon = {
+    16: "img/icon16_off.png",
+    24: "img/icon24_off.png",
+	32: "img/icon32_off.png",
+	48: "img/icon48_off.png",
+	128: "img/icon128_off.png"
+}
+
+function updatePageAction(tabId, toggled) {
     chrome.pageAction.setTitle({
         tabId: tabId,
         title: toggled ? toggleOffTitle : toggleOnTitle
     });
-}
 
-function updateIcon(tabId, toggled) {
     chrome.pageAction.setIcon({
         tabId: tabId,
-        path: toggled ? 'img/icon128.png' : 'img/icon128_off.png'
+        path: toggled ? toggledOnIcon : toggledOffIcon
     });
 }
 
@@ -19,7 +33,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
     if (message.action === 'activate_page_action') {
         const tabId = sender.tab.id;
 
-        updateTitle(tabId, true);
+        updatePageAction(tabId, true);
         chrome.pageAction.show(tabId);
     }
 });
@@ -28,7 +42,6 @@ chrome.pageAction.onClicked.addListener(function (tab) {
     const tabId = tab.id;
 
 	chrome.tabs.sendMessage(tabId, {action: 'toggle_simpl'}, function(response) {
-        updateTitle(tabId, response.toggled);
-        updateIcon(tabId, response.toggled);
+        updatePageAction(tabId, response.toggled);
     });
 });

--- a/gmail/pageActionHandler.js
+++ b/gmail/pageActionHandler.js
@@ -4,17 +4,17 @@ const toggleOffTitle = 'Temporarily disable Simplify';
 const toggledOnIcon = {
     16: "img/icon16.png",
     24: "img/icon24.png",
-	32: "img/icon32.png",
-	48: "img/icon48.png",
-	128: "img/icon128.png"
+    32: "img/icon32.png",
+    48: "img/icon48.png",
+    128: "img/icon128.png"
 }
 
 const toggledOffIcon = {
     16: "img/icon16_off.png",
     24: "img/icon24_off.png",
-	32: "img/icon32_off.png",
-	48: "img/icon48_off.png",
-	128: "img/icon128_off.png"
+    32: "img/icon32_off.png",
+    48: "img/icon48_off.png",
+    128: "img/icon128_off.png"
 }
 
 function updatePageAction(tabId, toggled) {
@@ -41,7 +41,7 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 chrome.pageAction.onClicked.addListener(function (tab) {
     const tabId = tab.id;
 
-	chrome.tabs.sendMessage(tabId, {action: 'toggle_simpl'}, function(response) {
+    chrome.tabs.sendMessage(tabId, {action: 'toggle_simpl'}, function(response) {
         updatePageAction(tabId, response.toggled);
     });
 });


### PR DESCRIPTION
I've tweaked the code to use dictionary instead of string, so the image will have corresponding to the pixel density sizing - [reference](https://developer.chrome.com/extensions/pageAction#method-setIcon).

![image](https://user-images.githubusercontent.com/34073648/56887755-0fcb1580-6a7b-11e9-95c5-a61066c6ca65.png)
![image](https://user-images.githubusercontent.com/34073648/56887759-178aba00-6a7b-11e9-8d85-c4d84aa4bf97.png)
