### PR TITLE
Make toggle shortcut use chrome command

### DIFF
--- a/gmail/manifest.json
+++ b/gmail/manifest.json
@@ -24,5 +24,13 @@
 		"scripts": [ "toggle.js" ],
 		"persistent": false
 	},
+	"commands": {
+		"_execute_page_action": {
+			"suggested_key": {
+				"default": "Alt+J",
+				"mac": "Command+J"
+			}
+		}
+	},
 	"content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self'"
 }

--- a/gmail/script.js
+++ b/gmail/script.js
@@ -26,12 +26,6 @@ function toggleSimpl() {
 
 // Handle Simplify keyboard shortcuts
 function handleToggleShortcut(event) {
-	// If Cmd+J was pressed, toggle simpl
-	if (event.metaKey && event.which == 74) {
-		toggleSimpl();
-		event.preventDefault();
-	}
-
 	// If Ctrl+M was pressed, toggle menu open/closed
 	if (event.ctrlKey && event.key == "m") {
 		document.querySelector('.aeN').classList.toggle('bhZ');


### PR DESCRIPTION
Tweaked toggle page action a bit to use command instead of `keydown` event. This gives the user more flexibility, as he could open `chrome://extensions/shortcuts` page in Chrome and change the shortcut to his or her liking. 
![image](https://user-images.githubusercontent.com/34073648/59549900-ed2e8680-8f6c-11e9-81d1-e252fcbb3eef.png)

And eliminates some unnecessary code 😉

I've also changed default toggle shortcut for Windows, because previous one was not working (Windows + J), and now it is Alt + J. For Mac it is still Command+J.

I hadn't ported Ctrl+M to use commands, because commands are global only, and toggle Gmail side menu is a local to the page thing. Unfortunately Chrome does not have concept of local shortcuts yet 😢

Please let me know if you want to change shortcuts or anything