### PR TITLE
Command fix

### DIFF
--- a/gmail/manifest.json
+++ b/gmail/manifest.json
@@ -24,5 +24,13 @@
 		"scripts": [ "toggle.js" ],
 		"persistent": false
 	},
+	"commands": {
+		"toggle-simpl": {
+			"description": "Toggle Simplify on / off",
+			"suggested_key": {
+				"default": "Ctrl+Shift+S"
+			}
+		}
+	},
 	"content_security_policy": "default-src 'none'; style-src 'self'; script-src 'self'; connect-src 'self'; img-src 'self'"
 }

--- a/gmail/script.js
+++ b/gmail/script.js
@@ -64,13 +64,6 @@ function handleToggleShortcut(event) {
 		}
 	}
 
-	// If Ctrl+Shift+S or Command+Shift+S was pressed, toggle Simpl
-	if ((event.ctrlKey && event.shiftKey && event.key === "S") || 
-		(event.metaKey && event.shiftKey && event.key === "s")) {
-		toggleSimpl();
-		event.preventDefault();
-	}
-
 	// If Ctrl+Shift+M or Command+Shift+M was pressed, toggle nav menu open/closed
 	if ((event.ctrlKey && event.shiftKey && event.key === "M") || 
 		(event.metaKey && event.shiftKey && event.key === "m")) {

--- a/gmail/toggle.js
+++ b/gmail/toggle.js
@@ -39,9 +39,24 @@ chrome.runtime.onMessage.addListener(function (message, sender, sendResponse) {
 });
 
 chrome.pageAction.onClicked.addListener(function (tab) {
-    const tabId = tab.id;
+    toggleSimplify(tab.id);
+});
 
+chrome.commands.onCommand.addListener(function(command) {
+    if (command === 'toggle-simpl') {
+        chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
+            toggleSimplify(tabs[0].id);    
+        });
+    }
+});
+
+function toggleSimplify(tabId) {
     chrome.tabs.sendMessage(tabId, {action: 'toggle_simpl'}, function(response) {
+        if (chrome.runtime.lastError) {
+            console.log(`Error sending request to content script: ${chrome.runtime.lastError.message}`);
+            return;
+        }
+
         updatePageAction(tabId, response.toggled);
     });
-});
+}


### PR DESCRIPTION
Tweak Simplify to use command and work even with hidden icon.

Now it works exactly as you've described and still uses command to provide flexibility and unified interface to the user.

Check it out:
![simplify-togle](https://user-images.githubusercontent.com/34073648/59593281-51328580-90fa-11e9-97d6-25499032d128.gif)
